### PR TITLE
Open Terminal if files are selected

### DIFF
--- a/Sources/OpenTerminal/main.swift
+++ b/Sources/OpenTerminal/main.swift
@@ -31,8 +31,8 @@ else {
 	
 	// This case is for launch from Finder directly.
 	fileUrls = selectionItems
-		.compactMap { $0 as? FinderApplicationFileProtocol }
-		.compactMap { $0.url }
+		.flatMap { $0 as? FinderApplicationFileProtocol }
+		.flatMap { $0.url }
 }
 
 let toDir: (URL) -> (URL) = {
@@ -49,8 +49,8 @@ let toDir: (URL) -> (URL) = {
 }
 
 Set(fileUrls
-	.compactMap { URL(string: $0) }
-	.compactMap(toDir))
+	.flatMap { URL(string: $0) }
+	.flatMap(toDir))
 	.forEach { url in
 
 	terminal.open!(with: [url.path])

--- a/Sources/OpenTerminal/main.swift
+++ b/Sources/OpenTerminal/main.swift
@@ -11,6 +11,8 @@ import ScriptingBridge
 let finder = SBApplication(bundleIdentifier: "com.apple.Finder")! as FinderApplicationProtocol
 let terminal = SBApplication(bundleIdentifier: "com.apple.Terminal")! as TerminalApplicationProtocol
 
+let manager = FileManager()
+
 let selection = finder.selection!
 let selectionItems = selection.get() as! Array<AnyObject>
 
@@ -33,8 +35,22 @@ else {
 		.compactMap { $0.url }
 }
 
-fileUrls
+let toDir: (URL) -> (URL) = {
+	url in
+	
+	var isDir:ObjCBool = false
+	manager.fileExists(atPath: url.path, isDirectory: &isDir)
+	
+	if isDir.boolValue {
+		return url
+	} else {
+		return url.deletingLastPathComponent()
+	}
+}
+
+Set(fileUrls
 	.compactMap { URL(string: $0) }
+	.compactMap(toDir))
 	.forEach { url in
 
 	terminal.open!(with: [url.path])


### PR DESCRIPTION
Linked to #2 .
If files are selected open a Terminal at the file's parent directory.
If directory are selected the behavior does not change from the previous one. It is possible to select both file and directories.

If multiple files are selected a Set is used to prevent opening multiple Terminal in the same directory.

(I don't know nothing about Swift so if there is a better way to do what I did, please do. Mostly the `isDir` function, I feel that it is weird to use pointers)